### PR TITLE
Fix tests

### DIFF
--- a/test/dhall_clj/parser_test.clj
+++ b/test/dhall_clj/parser_test.clj
@@ -346,7 +346,7 @@
 
 
 (defn valid-testcases []
-  (let [all (success-testcases test-folder)]
+  (let [all (success-testcases (str test-folder "/success"))]
     (->> problematic
        (map #(->> % (apply io/file) str))
        (apply dissoc all))))
@@ -360,7 +360,7 @@
 
 
 (defn valid-failing-testcases []
-  (let [all (failure-testcases test-folder)]
+  (let [all (failure-testcases (str test-folder "/failure"))]
     (->> problematic
        (map #(->> % (apply io/file) str))
        (apply dissoc all))))

--- a/test/dhall_clj/test_utils.clj
+++ b/test/dhall_clj/test_utils.clj
@@ -27,9 +27,11 @@
                  (remove failure-case?))
         map-of-testcases (group-by #(->> % str (drop-last 7) (apply str)) files)]
     (map-vals
-      (fn [[actual expected]]
-        {:actual   (slurp actual)
-         :expected (slurp expected)})
+      (fn [a-and-b]
+        ;; We sort so we get the A.dhall file first
+        (let [[actual expected] (sort a-and-b)]
+          {:actual   (slurp actual)
+           :expected (slurp expected)}))
       map-of-testcases)))
 
 (defn failure-testcases


### PR DESCRIPTION
We have to sort the input files, to the `A.dhall` always gets picked up as the right source one.